### PR TITLE
Misc Fixes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.1]
 ### Changed
+ - (Linux) Fix directories not being sorted separately from tags.
  - Don't tell people to run as admin when no tags were extracted.
  - Hopefully sped up tag sorting.
  - Name first column in hierarchy view 'name'

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Don't tell people to run as admin when no tags were extracted.
  - Hopefully sped up tag sorting.
+ - Name first column in hierarchy view 'name'
 
 ## [2.4.0]
 ### Added

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Name first column in hierarchy view 'name'.
  - Remove fallback icon and about image locations.
  - Fix missing license in distributions.
+ - Default setting for generating compressed vertices is now True.
 
 ## [2.4.0]
 ### Added

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1]
+### Changed
+ - Don't tell people to run as admin when no tags were extracted.
+ - Hopefully sped up tag sorting.
+
 ## [2.4.0]
 ### Added
  - Added \_\_main\_\_ so Refinery can be executed using `python -m refinery` or just `refinery` on some systems.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Display pointers as HEX.
  - Don't tell people to run as admin when no tags were extracted.
  - Hopefully sped up tag sorting.
- - Name first column in hierarchy view 'name'
+ - Name first column in hierarchy view 'name'.
+ - Remove fallback icon and about image locations.
 
 ## [2.4.0]
 ### Added

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.4.1]
 ### Changed
  - (Linux) Fix directories not being sorted separately from tags.
+ - Display pointers as HEX.
  - Don't tell people to run as admin when no tags were extracted.
  - Hopefully sped up tag sorting.
  - Name first column in hierarchy view 'name'

--- a/refinery/__init__.py
+++ b/refinery/__init__.py
@@ -12,8 +12,8 @@
 # ##############
 __author__ = "Devin Bobadilla, Michelle van der Graaf"
 #           YYYY.MM.DD
-__date__ = "2020.02.29"
-__version__ = (2, 4, 0)
+__date__ = "2020.03.07"
+__version__ = (2, 4, 1)
 __website__ = "https://github.com/Sigmmma/refinery"
 __all__ = (
     'defs', 'heuristic_deprotection', 'repl', 'tag_index', 'widgets', 'windows',

--- a/refinery/core.py
+++ b/refinery/core.py
@@ -166,7 +166,7 @@ class RefineryCore:
     recursive = False
     decode_adpcm = True
     generate_uncomp_verts = True
-    generate_comp_verts = False
+    generate_comp_verts = True
     use_tag_index_for_script_names = True
     use_scenario_names_for_script_names = True
     bitmap_extract_keep_alpha = True

--- a/refinery/crc_functions.py
+++ b/refinery/crc_functions.py
@@ -14,7 +14,7 @@ from traceback import format_exc
 
 _crc=0
 __all__ = ()
-# this was intentionally obfuscated at one point, and I don't
+# this was intentionally obfuscated at one point, and Moses doesn't
 # have the unobfuscated version, so it's staying as-is
 def J(l=[0,0,0]):
  if l[2]<0:return U([l[0],l[1],l[2]])

--- a/refinery/editor_constants.py
+++ b/refinery/editor_constants.py
@@ -14,21 +14,9 @@ REFINERYLIB_DIR = Path(__file__).parent
 
 REFINERY_ICON_PATH = Path(REFINERYLIB_DIR, "refinery.ico")
 if not REFINERY_ICON_PATH.is_file():
-    REFINERY_ICON_PATH = Path(REFINERYLIB_DIR, "icons", "refinery.ico")
-if not REFINERY_ICON_PATH.is_file():
-    REFINERY_ICON_PATH = Path(WORKING_DIR, "refinery.ico")
-if not REFINERY_ICON_PATH.is_file():
-    REFINERY_ICON_PATH = Path(WORKING_DIR, "icons", "refinery.ico")
-if not REFINERY_ICON_PATH.is_file():
     REFINERY_ICON_PATH = ""
 
 REFINERY_BITMAP_PATH = Path(REFINERYLIB_DIR, "refinery.png")
-if not REFINERY_BITMAP_PATH.is_file():
-    REFINERY_BITMAP_PATH = Path(REFINERYLIB_DIR, "icons", "refinery.png")
-if not REFINERY_BITMAP_PATH.is_file():
-    REFINERY_BITMAP_PATH = Path(WORKING_DIR, "refinery.png")
-if not REFINERY_BITMAP_PATH.is_file():
-    REFINERY_BITMAP_PATH = Path(WORKING_DIR, "icons", "refinery.png")
 if not REFINERY_BITMAP_PATH.is_file():
     REFINERY_BITMAP_PATH = ""
 

--- a/refinery/main.py
+++ b/refinery/main.py
@@ -1395,8 +1395,7 @@ class Refinery(tk.Tk, BinillaWidget, RefineryCore):
                           sum(len(item) for item in data_by_map.values())
 
         if not items_extracted:
-            print("Nothing was extracted. This might be a permissions issue.\n"
-                  "Close Refinery and run it as admin to potentially fix this.")
+            print("Nothing was extracted. This might be a permissions issue.")
 
     def prompt_globals_overwrite(self, halo_map, tag_id):
         map_name = halo_map.map_name

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -110,8 +110,8 @@ class ExplorerHierarchyTree(HierarchyFrame):
             tags_tree.heading("class1", text='class 1')
             tags_tree.heading("class2", text='class 2')
             tags_tree.heading("class3", text='class 3')
-            tags_tree.heading("magic",  text='pointer(memory)')
-            tags_tree.heading("pointer", text='pointer(file)')
+            tags_tree.heading("magic",  text='pointer(MEM)')
+            tags_tree.heading("pointer", text='pointer(FILE)')
             tags_tree.heading("index_id",  text='index id')
 
             tags_tree.column("#0", minwidth=100, width=200)
@@ -447,10 +447,12 @@ class ExplorerHierarchyTree(HierarchyFrame):
         if tag_index_ref.indexed and pointer_converter and not is_h1_rsrc_map:
             pointer = "not in map"
         elif pointer_converter is not None:
-            pointer = pointer_converter.v_ptr_to_f_ptr(
+            pointer = '%08X' % pointer_converter.v_ptr_to_f_ptr(
                 tag_index_ref.meta_offset)
         else:
             pointer = 0
+
+        meta_offset = '%08X' % tag_index_ref.meta_offset
 
         try:
             cls1 = cls2 = cls3 = ""
@@ -468,7 +470,7 @@ class ExplorerHierarchyTree(HierarchyFrame):
                 parent_iid, 'end', iid=str(tag_id),
                 tags=("item", ), text=tag_path,
                 values=(cls1, cls2, cls3,
-                        tag_index_ref.meta_offset, pointer, tag_id))
+                        meta_offset, pointer, '%04X' % tag_id))
             self.tree_id_to_index_ref[tag_id] = tag_index_ref
         except Exception:
             print(format_exc())

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -8,6 +8,7 @@
 #
 
 import os
+import ntpath
 import refinery
 import tkinter as tk
 
@@ -412,7 +413,7 @@ class ExplorerHierarchyTree(HierarchyFrame):
         # add all the directories before files
         # put the directories in sorted by name
         indices_by_dirpath = {
-            os.path.dirname(block[0]): i
+            ntpath.dirname(block[0]): i
             for i, block in enumerate(sorted_index_refs)
             }
         for dir_path in sorted(indices_by_dirpath):

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -90,17 +90,15 @@ class ExplorerHierarchyTree(HierarchyFrame):
                 new_sorting.setdefault(
                     index_ref[0], []).append(index_ref)
 
-        sorted_index_refs = [None]*len(sortable_index_refs)
-        i = 0
+        sorted_index_refs = []
         for key in sorted(new_sorting):
             for index_ref in new_sorting[key]:
-                sorted_index_refs[i] = index_ref
-                i += 1
+                sorted_index_refs.append(index_ref)
 
         if self.reverse_sorted:
-            return list(reversed(sorted_index_refs[:i]))
+            return list(reversed(sorted_index_refs))
 
-        return sorted_index_refs[:i]
+        return sorted_index_refs
 
     def setup_columns(self):
         tags_tree = self.tags_tree

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -25,6 +25,9 @@ from supyr_struct.defs.frozen_dict import FrozenDict
 
 no_op = lambda *a, **kw: None
 
+def _ensure_backslash_for_folder(folder_path):
+    return str(folder_path).rstrip('\\') + '\\'
+
 TREE_SORT_METHODS = FrozenDict(
     {0: "name", 4:"pointer", 5:"pointer", 6:"index_id"})
 
@@ -481,7 +484,7 @@ class ExplorerHierarchyTree(HierarchyFrame):
         if abs_dir_path:
             # directories must end with a backslash.
             # this is how we distinguish dirs from files inside of maps.
-            abs_dir_path = abs_dir_path.rstrip('\\') + '\\'
+            abs_dir_path = _ensure_backslash_for_folder(abs_dir_path)
 
         if self.tags_tree.exists(abs_dir_path):
             return abs_dir_path
@@ -500,7 +503,7 @@ class ExplorerHierarchyTree(HierarchyFrame):
         if abs_dir_path:
             # directories must end with a backslash.
             # this is how we distinguish dirs from files inside of maps.
-            abs_dir_path = abs_dir_path.rstrip('\\') + "\\"
+            abs_dir_path = _ensure_backslash_for_folder(abs_dir_path)
 
         if not self.tags_tree.exists(abs_dir_path):
             # add the directory to the treeview

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -91,11 +91,9 @@ class ExplorerHierarchyTree(HierarchyFrame):
                     index_ref[0], []).append(index_ref)
 
         sorted_index_refs = [None]*len(sortable_index_refs)
-        i = 0
-        for key in sorted(new_sorting):
+        for i, key in enumerate(sorted(new_sorting)):
             for index_ref in new_sorting[key]:
                 sorted_index_refs[i] = index_ref
-                i += 1
 
         if self.reverse_sorted:
             return list(reversed(sorted_index_refs[:i]))

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -26,6 +26,10 @@ from supyr_struct.defs.frozen_dict import FrozenDict
 no_op = lambda *a, **kw: None
 
 def _ensure_backslash_for_folder(folder_path):
+    '''
+    Directories must end with a backslash for them to be identified as
+    directories in the ExplorerHierarchyTree.
+    '''
     return str(folder_path).rstrip('\\') + '\\'
 
 TREE_SORT_METHODS = FrozenDict(
@@ -482,8 +486,6 @@ class ExplorerHierarchyTree(HierarchyFrame):
     def add_folder_path(self, dir_parts):
         abs_dir_path = str(PureWindowsPath(*dir_parts))
         if abs_dir_path:
-            # directories must end with a backslash.
-            # this is how we distinguish dirs from files inside of maps.
             abs_dir_path = _ensure_backslash_for_folder(abs_dir_path)
 
         if self.tags_tree.exists(abs_dir_path):
@@ -501,8 +503,6 @@ class ExplorerHierarchyTree(HierarchyFrame):
 
         abs_dir_path = parent_dir + this_dir
         if abs_dir_path:
-            # directories must end with a backslash.
-            # this is how we distinguish dirs from files inside of maps.
             abs_dir_path = _ensure_backslash_for_folder(abs_dir_path)
 
         if not self.tags_tree.exists(abs_dir_path):

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -91,9 +91,11 @@ class ExplorerHierarchyTree(HierarchyFrame):
                     index_ref[0], []).append(index_ref)
 
         sorted_index_refs = [None]*len(sortable_index_refs)
-        for i, key in enumerate(sorted(new_sorting)):
+        i = 0
+        for key in sorted(new_sorting):
             for index_ref in new_sorting[key]:
                 sorted_index_refs[i] = index_ref
+                i += 1
 
         if self.reverse_sorted:
             return list(reversed(sorted_index_refs[:i]))

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -476,8 +476,9 @@ class ExplorerHierarchyTree(HierarchyFrame):
     def add_folder_path(self, dir_parts):
         abs_dir_path = str(PureWindowsPath(*dir_parts))
         if abs_dir_path:
-            abs_dir_path += "\\"  # directories must end with a backslash.
-            #                       this is how we distinguish dirs from files
+            # directories must end with a backslash.
+            # this is how we distinguish dirs from files inside of maps.
+            abs_dir_path = abs_dir_path.rstrip('\\') + '\\'
 
         if self.tags_tree.exists(abs_dir_path):
             return abs_dir_path
@@ -494,8 +495,9 @@ class ExplorerHierarchyTree(HierarchyFrame):
 
         abs_dir_path = parent_dir + this_dir
         if abs_dir_path:
-            abs_dir_path += "\\"  # directories must end with a backslash.
-            #                       this is how we distinguish dirs from files
+            # directories must end with a backslash.
+            # this is how we distinguish dirs from files inside of maps.
+            abs_dir_path = abs_dir_path.rstrip('\\') + "\\"
 
         if not self.tags_tree.exists(abs_dir_path):
             # add the directory to the treeview

--- a/refinery/widgets/explorer_hierarchy_tree.py
+++ b/refinery/widgets/explorer_hierarchy_tree.py
@@ -106,7 +106,7 @@ class ExplorerHierarchyTree(HierarchyFrame):
             # dont want to do this more than once
             tags_tree['columns'] = ('class1', 'class2', 'class3',
                                     'magic', 'pointer', 'index_id')
-            tags_tree.heading("#0", text='')
+            tags_tree.heading("#0", text='name')
             tags_tree.heading("class1", text='class 1')
             tags_tree.heading("class2", text='class 2')
             tags_tree.heading("class3", text='class 3')


### PR DESCRIPTION
 - (Linux) Fix directories not being sorted separately from tags.
	Closes #15
	Was a problem with the wrong path library being used on Linux.
 - Display pointers as HEX.
	Convenience change.
 - Don't tell people to run as admin when no tags were extracted.
	Closes #19
 - Hopefully sped up tag sorting.
	There was a comment about the reload function being really slow.
	I haven't tested before, but after I made some changes to simplify the code there. The speed was pretty good.
 - Name first column in hierarchy view 'name'.
	It had no name before.
 - Remove fallback icon and about image locations.
	This was originally done for the wacky way MEKe was set up. Luckly there is now a set way that will always work to find the icon.
 - Default setting for generating compressed vertices is now True.
	Apparently not having this set to true can break lightmap generation with Tool. So, we're changing it to True.